### PR TITLE
Implement Deferred Numpy Import in setup.py for Build Compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.11"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel cython
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install pytest scipy
           pip install .

--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install cibuildwheel
         run: |
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -7,7 +7,7 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     env:
-      CIBW_BUILD: cp310-*
+      CIBW_BUILD: cp311-*
       CIBW_BEFORE_BUILD: pip install Cython numpy
     runs-on: ${{ matrix.os }}
     strategy:
@@ -51,7 +51,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel cython
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Build sdist

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     env:
       CIBW_SKIP: pp*
-      CIBW_BEFORE_BUILD: pip install Cython numpy
+      CIBW_BEFORE_BUILD: pip install Cython numpy wheel
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel cython
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Build sdist

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install cibuildwheel
         run: |
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           
       - name: Install dependencies
         run: |

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 class build_ext(_build_ext):
     def run(self):
+        # defer import
         import numpy as np
         self.include_dirs.append(np.get_include())
         super().run()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,14 @@
 from Cython.Build import cythonize
 from setuptools import setup, Extension
-import numpy as np
+from setuptools.command.build_ext import build_ext as _build_ext
+
+
+class build_ext(_build_ext):
+    def run(self):
+        import numpy as np
+        self.include_dirs.append(np.get_include())
+        super().run()
+
 
 with open("README.md") as fp:
     long_description = fp.read()
@@ -23,7 +31,7 @@ ckwrap = Extension(
     name="_ckwrap",
     sources=sources,
     language="c++",
-    include_dirs=["Ckmeans.1d.dp/src", np.get_include()],
+    include_dirs=["Ckmeans.1d.dp/src"],
     extra_compile_args=["-std=c++11", "-g0"],
 )
 
@@ -42,4 +50,5 @@ setup(
     ext_modules=cythonize(ckwrap),
     install_requires=["numpy", "Cython"],
     tests_require=["pytest", "scipy"],
+    cmdclass={'build_ext': build_ext},
 )


### PR DESCRIPTION
This pull request introduces a small enhancement to the build process of our Python library. It addresses the issue where the library requires numpy to be installed prior to the compilation process. Previously, the setup.py script imported numpy at the top of the file, leading to potential complications when numpy was not already installed in the environment. 

e.g. when installing both from requirements.txt file it didn't work due to file-wide import

Also bumped tests for python 3.11, feel free to revert it