### PR TITLE
Transition to PEP 518 Build System spec with pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,24 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ckwrap"
-version = "1.2.0"
+version = "1.2.1"
+dependencies = [
+    "numpy",
+    "Cython",
+]
 description = "Python wrapper for Ckmeans.1d.dp, 4.3.5."
 authors = [{name = "djdt"}]
 license = {file = "LICENSE"}
 readme = "README.md"
-urls = {Homepage = "https://github.com/djdt/ckwrap"}
 
-dependencies = [
-    "numpy",
-    "Cython"
+[project.urls]
+Homepage = "https://github.com/djdt/ckwrap"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "scipy",
 ]
-optional-dependencies = {"test" = ["pytest", "scipy"]}
 
 [tool.setuptools]
 packages = ["ckwrap"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ckwrap"
+version = "1.2.0"
+description = "Python wrapper for Ckmeans.1d.dp, 4.3.5."
+authors = [{name = "djdt"}]
+license = {file = "LICENSE"}
+readme = "README.md"
+urls = {Homepage = "https://github.com/djdt/ckwrap"}
+
+dependencies = [
+    "numpy",
+    "Cython"
+]
+optional-dependencies = {
+    "test": ["pytest", "scipy"]
+}
+
+[tool.cython]
+# Cython specific settings, if any
+
+[tool.setuptools]
+packages = ["ckwrap"]
+package_dir = {"" = "."}
+package_data = {"ckwrap": ["*.pxd"]}
+zip_safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ dependencies = [
     "Cython"
 ]
 optional-dependencies = {"test" = ["pytest", "scipy"]}
+
+[tool.setuptools]
+packages = ["ckwrap"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,6 @@ optional-dependencies = {
     "test": ["pytest", "scipy"]
 }
 
-[tool.cython]
-# Cython specific settings, if any
-
 [tool.setuptools]
 packages = ["ckwrap"]
 package_dir = {"" = "."}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,4 @@ dependencies = [
     "numpy",
     "Cython"
 ]
-optional-dependencies = {
-    "test": ["pytest", "scipy"]
-}
-
-[tool.setuptools]
-packages = ["ckwrap"]
-package_dir = {"" = "."}
-package_data = {"ckwrap": ["*.pxd"]}
-zip_safe = false
+optional-dependencies = {"test" = ["pytest", "scipy"]}

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,28 @@
-from Cython.Build import cythonize
 from setuptools import setup, Extension
 import numpy as np
+from Cython.Build import cythonize
 
-with open("README.md") as fp:
-    long_description = fp.read()
-
-sources = [
-    "ckwrap/_ckwrap.pyx",
-    "Ckmeans.1d.dp/src/dynamic_prog.cpp",
-    "Ckmeans.1d.dp/src/EWL2_dynamic_prog.cpp",
-    "Ckmeans.1d.dp/src/EWL2_fill_log_linear.cpp",
-    "Ckmeans.1d.dp/src/EWL2_fill_quadratic.cpp",
-    "Ckmeans.1d.dp/src/EWL2_fill_SMAWK.cpp",
-    "Ckmeans.1d.dp/src/fill_log_linear.cpp",
-    "Ckmeans.1d.dp/src/fill_quadratic.cpp",
-    "Ckmeans.1d.dp/src/fill_SMAWK.cpp",
-    "Ckmeans.1d.dp/src/select_levels.cpp",
-    "Ckmeans.1d.dp/src/weighted_select_levels.cpp",
-]
-
+# Extension definition remains similar to your current setup.py
 ckwrap = Extension(
     name="_ckwrap",
-    sources=sources,
+    sources=[
+        "ckwrap/_ckwrap.pyx",
+        "Ckmeans.1d.dp/src/dynamic_prog.cpp",
+        "Ckmeans.1d.dp/src/EWL2_dynamic_prog.cpp",
+        "Ckmeans.1d.dp/src/EWL2_fill_log_linear.cpp",
+        "Ckmeans.1d.dp/src/EWL2_fill_quadratic.cpp",
+        "Ckmeans.1d.dp/src/EWL2_fill_SMAWK.cpp",
+        "Ckmeans.1d.dp/src/fill_log_linear.cpp",
+        "Ckmeans.1d.dp/src/fill_quadratic.cpp",
+        "Ckmeans.1d.dp/src/fill_SMAWK.cpp",
+        "Ckmeans.1d.dp/src/select_levels.cpp",
+        "Ckmeans.1d.dp/src/weighted_select_levels.cpp",
+    ],
     language="c++",
     include_dirs=["Ckmeans.1d.dp/src", np.get_include()],
     extra_compile_args=["-std=c++11", "-g0"],
 )
 
-
 setup(
-    name="ckwrap",
-    version="1.2.0",
-    description="Python wrapper for Ckmeans.1d.dp, 4.3.5.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="djdt",
-    license="LGPL",
-    url="https://github.com/djdt/ckwrap",
-    packages=["ckwrap"],
-    package_data={"ckwrap": ["*.pxd"]},
     ext_modules=cythonize(ckwrap),
-    install_requires=["numpy", "Cython"],
-    tests_require=["pytest", "scipy"],
 )


### PR DESCRIPTION
## Introduction

This pull request updates the `ckwrap` project's build system to align with [PEP 518](https://www.python.org/dev/peps/pep-0518/), introducing a `pyproject.toml` file and minimizing the reliance on `setup.py`. This transition streamlines the build process and enhances compatibility with modern Python tooling

## Changes Made

- Introduced a `pyproject.toml` file to specify build system requirements and project metadata.
- Retained a minimal `setup.py` for compatibility purposes, focusing on extension module configurations that are not yet fully supported by `pyproject.toml`.

## Benefits

- **Enhanced Compatibility**: Aligns `ckwrap` with current Python packaging standards, improving compatibility with tools like `pip`, `poetry`, and others that support PEP 518.
- **Simplified Build Process**: Centralizes project configuration and reduces complexity, making it easier for new contributors to set up and work with the project.
- **Future-proofing**: Prepares `ckwrap` for future Python packaging enhancements and makes it easier to adopt additional PEPs related to packaging and build processes.