### PR TITLE
Enable parallel emulated aarch64 builds, add MacOS-14 for osx/arm64

### DIFF
--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -4,34 +4,54 @@ on:
   workflow_dispatch:
 
 jobs:
+  generate-wheels-matrix:
+    name: Generate wheels matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cibuildwheel
+        run: pipx install cibuildwheel==2.16.5
+      - id: set-matrix
+        run: |
+          MATRIX=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux \
+              | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
+              && jq -nRc '{"os": "ubuntu-20.04"}'
+            } | jq -sc
+          );
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+    env:
+      CIBW_ARCHS_LINUX: aarch64
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} ${{ matrix.only }}
     runs-on: ${{ matrix.os }}
+    needs: generate-wheels-matrix
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
+        os: [windows-2019, macOS-11, macOS-14]
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
-        name: Install Python
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
         with:
-          python-version: "3.11"
+          platforms: all
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==2.16.2
-          
-      - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+      - uses: pypa/cibuildwheel@v2.16.5
+        with:
+          only: ${{ matrix.only }}
           
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.only || 'all' }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,34 +6,54 @@ on:
   workflow_dispatch:
 
 jobs:
+  generate-wheels-matrix:
+    name: Generate wheels matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cibuildwheel
+        run: pipx install cibuildwheel==2.16.5
+      - id: set-matrix
+        run: |
+          MATRIX=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux \
+              | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
+              && jq -nRc '{"os": "ubuntu-20.04"}'
+            } | jq -sc
+          );
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+    env:
+      CIBW_ARCHS_LINUX: aarch64
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} ${{ matrix.only }}
     runs-on: ${{ matrix.os }}
+    needs: generate-wheels-matrix
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
+        os: [windows-2019, macOS-11, macOS-14]
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
-        name: Install Python
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
         with:
-          python-version: "3.11"
+          platforms: all
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==2.16.2
-          
-      - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+      - uses: pypa/cibuildwheel@v2.16.5
+        with:
+          only: ${{ matrix.only }}
           
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.only || 'all' }}
           path: ./wheelhouse/*.whl
 
   build_sdist:


### PR DESCRIPTION
The aarch64 builds (because they're emulated) ended up being quite a bit slower individually than their x86, x86_64 counterparts - hence the parallel build.

I also noticed the earlier python versions are a fair bit slower to build than more recent ones - parallel builds for those would be a relatively easy extension, involving the following change:
```diff
      - id: set-matrix
        run: |
          MATRIX=$(
            {
              cibuildwheel --print-build-identifiers --platform linux \
-             | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
-             && jq -nRc '{"os": "ubuntu-20.04"}'
+             | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}'
            } | jq -sc
          );
          echo "include=$MATRIX" >> $GITHUB_OUTPUT
    env:
-     CIBW_ARCHS_LINUX: aarch64
+     CIBW_ARCHS_LINUX: auto aarch64
```